### PR TITLE
fix(build):

### DIFF
--- a/stablediffusion.hpp
+++ b/stablediffusion.hpp
@@ -311,7 +311,7 @@ static inline ncnn::Mat randn_4_64_64( int seed )
 {
     std::vector<float> arr;
     {
-        std::mt19937 gen{ static_cast<unsigned long>( seed ) };
+        std::mt19937 gen{ static_cast<std::mt19937::result_type>(seed) };
         std::normal_distribution<float> d{0.0f, 1.0f};
         arr.resize( 64 * 64 * 4 );
         std::for_each( arr.begin(), arr.end(), [&]( float & x )


### PR DESCRIPTION
 - error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>::result_type' (aka 'unsigned int') in initializer list [-Wc++11-narrowing] std::mt19937 gen{ static_cast<unsigned long>( seed ) };