### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ stablediffusion.o: ncnn/build/src/libncnn.a
 	$(CXX) $(CXXFLAGS) stablediffusion.cpp -o stablediffusion-hires.o -c $(LDFLAGS)
 
 unpack: ncnn/build/src/libncnn.a
-	mkdir -p unpack && cd unpack && ar x ../ncnn/build/src/libncnn.a
+	mkdir -p unpack && cd unpack && ar x ../ncnn/build/src/libncnn.a && rm __.SYMDEF
 
 libstablediffusion.a: stablediffusion.o unpack $(EXTRA_TARGETS)
 	ar src libstablediffusion.a stablediffusion-hires.o stablediffusion.o $(shell ls unpack/* | xargs echo)


### PR DESCRIPTION
Deletes the SYMDEF file extracted from the former archive to avoid linking implications when creating libstablediffusion.a

The content of libncnn.a is taken to create libstablediffusion.a. However, this results in having two __.SYMDEF files in the new archive. This is tolerated by the linker on Linux because the gnu flavor just picks the first file, the bsd linker however refuses to link if 2 SYMDEF files live in the archive.
So to fix this issue, the SYMDEF file coming from ncnn has to be deleted before the new archive gets created.

Fixes https://github.com/mudler/LocalAI/issues/1443