### PR TITLE
fix: pass through GNUMake jobserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CXXFLAGS += -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function
 $(info I llama.cpp build info: )
 
 ncnn/build/src/libncnn.a:
-	cd ncnn && mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DNCNN_VULKAN=OFF -DNCNN_BUILD_EXAMPLES=ON .. && make
+	cd ncnn && mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DNCNN_VULKAN=OFF -DNCNN_BUILD_EXAMPLES=ON .. && $(MAKE)
 	cd ncnn && cp -rf src/* ./
 
 stablediffusion.o: ncnn/build/src/libncnn.a


### PR DESCRIPTION
One more fix that I missed in the last PR to ensure the GNUMake jobserver is passed through to preserve parallel builds